### PR TITLE
requests>=1.2.2 was required and missing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 -e git://github.com/influence-usa/python-opencivicdata-django.git@disclosures#egg=opencivicdata
 -e git://github.com/influence-usa/pupa.git@disclosures#egg=pupa
+requests>=1.2.2


### PR DESCRIPTION
It was missing from installation when trying to bootstrap my installation
